### PR TITLE
+ new wrap modes for textures

### DIFF
--- a/src/main/java/org/adddxdx/briefexample/Floor.java
+++ b/src/main/java/org/adddxdx/briefexample/Floor.java
@@ -19,11 +19,9 @@
 package org.adddxdx.briefexample;
 
 import org.adddxdx.engine.Actor;
-import org.adddxdx.fio.Image;
 import org.adddxdx.graphics.Mesh;
 import org.adddxdx.graphics.support.components.MeshSkin;
 import org.adddxdx.graphics.support.materials.DefaultMaterial;
-import org.adddxdx.graphics.support.textures.Texture;
 import org.adddxdx.math.Vector2;
 import org.adddxdx.math.Vector3;
 

--- a/src/main/java/org/adddxdx/engine/Resources.java
+++ b/src/main/java/org/adddxdx/engine/Resources.java
@@ -22,8 +22,8 @@ import org.adddxdx.graphics.Material;
 import org.adddxdx.graphics.Mesh;
 import org.adddxdx.graphics.Shader;
 import org.adddxdx.graphics.ShaderDescription;
+import org.adddxdx.graphics.Texture;
 import org.adddxdx.graphics.support.primitives.PrimitiveType;
-import org.adddxdx.graphics.support.textures.Texture;
 
 public interface Resources {
     <TMaterial extends Material> TMaterial getMaterial(Class<TMaterial> clazz);
@@ -31,4 +31,5 @@ public interface Resources {
     Mesh getPrimitive(PrimitiveType primitiveType);
     Mesh getMesh(String path);
     Texture getTexture(String path);
+    Texture getTexture(String path, Texture.WrapMode wrapMode);
 }

--- a/src/main/java/org/adddxdx/engine/ResourcesImpl.java
+++ b/src/main/java/org/adddxdx/engine/ResourcesImpl.java
@@ -26,22 +26,23 @@ import org.adddxdx.graphics.MaterialFactory;
 import org.adddxdx.graphics.Mesh;
 import org.adddxdx.graphics.Shader;
 import org.adddxdx.graphics.ShaderDescription;
+import org.adddxdx.graphics.Texture;
 import org.adddxdx.graphics.support.primitives.PrimitiveType;
 import org.adddxdx.graphics.support.primitives.PrimitivesFactory;
-import org.adddxdx.graphics.support.textures.Texture;
+import org.adddxdx.graphics.ImageTexture;
 
 import java.io.File;
 import java.net.URL;
 
 class ResourcesImpl implements Resources, Destroyable {
 
-    private ResourceManager<Texture> mTextureManager;
+    private ResourceManager<Image> mImageManager;
     private ResourceManager<Mesh> mMeshManager;
     private PrimitivesFactory mPrimitivesFactory;
     private MaterialFactory mMaterialFactory;
 
     ResourcesImpl(Setting setting) {
-        mTextureManager = new ResourceManager<>(path -> new Texture(Image.load(open(path))));
+        mImageManager = new ResourceManager<>(path -> Image.load(open(path)));
         mMeshManager = new ResourceManager<>(path -> WavefrontObject.fromFile(open(path)).getMesh());
         mPrimitivesFactory = setting.get(PrimitivesFactory.class);
         mMaterialFactory = setting.get(MaterialFactory.class);
@@ -77,12 +78,17 @@ class ResourcesImpl implements Resources, Destroyable {
 
     @Override
     public Texture getTexture(String path) {
-        return mTextureManager.load(path);
+        return new ImageTexture(mImageManager.load(path));
+    }
+
+    @Override
+    public Texture getTexture(String path, ImageTexture.WrapMode wrapMode) {
+         return new ImageTexture(mImageManager.load(path), wrapMode);
     }
 
     @Override
     public void destroy() {
-        mTextureManager.destroy();
+        mImageManager.destroy();
         mMeshManager.destroy();
         mMaterialFactory.destroy();
     }

--- a/src/main/java/org/adddxdx/graphics/GlDepthTexture.java
+++ b/src/main/java/org/adddxdx/graphics/GlDepthTexture.java
@@ -21,7 +21,6 @@ package org.adddxdx.graphics;
 import org.adddxdx.math.Size;
 
 import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.opengl.GL13.GL_CLAMP_TO_BORDER;
 import static org.lwjgl.opengl.GL14.*;
 
 class GlDepthTexture extends GlTexture {
@@ -31,22 +30,16 @@ class GlDepthTexture extends GlTexture {
     }
 
     GlDepthTexture(Size size) {
-        super(size);
+        super(size, WrapMode.CLAMP_TO_EDGE);
     }
 
     @Override
-    protected int doInit(Size size) {
-        int textureHandle = glGenTextures();
-        glBindTexture(GL_TEXTURE_2D, textureHandle);
-        glTexImage2D(GL_TEXTURE_2D, 0,  GL_DEPTH_COMPONENT16, size.getWidth(), size.getHeight(), 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
+    protected void onInit() {
+        glTexImage2D(GL_TEXTURE_2D, 0,  GL_DEPTH_COMPONENT16, getWidth(), getHeight(), 0, GL_DEPTH_COMPONENT, GL_FLOAT, 0);
         glTexParameterfv(GL_TEXTURE_2D, GL_TEXTURE_BORDER_COLOR, new float[] {1, 0, 0, 0});
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_BORDER);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_BORDER);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_FUNC, GL_LEQUAL);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_COMPARE_MODE, GL_COMPARE_R_TO_TEXTURE);
-
-        return textureHandle;
     }
 }

--- a/src/main/java/org/adddxdx/graphics/GlRenderTexture.java
+++ b/src/main/java/org/adddxdx/graphics/GlRenderTexture.java
@@ -56,8 +56,9 @@ class GlRenderTexture implements RenderTarget {
 
         glDrawBuffer(textureAttachmentType == GL_DEPTH_ATTACHMENT ? GL_NONE : textureAttachmentType);
 
-        if(glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE)
+        if(glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
             throw new IllegalStateException("Error initializing framebuffer for render texture.");
+        }
     }
 
     private int getTextureAttachmentType() {

--- a/src/main/java/org/adddxdx/graphics/GlRgbTexture.java
+++ b/src/main/java/org/adddxdx/graphics/GlRgbTexture.java
@@ -29,16 +29,13 @@ class GlRgbTexture extends GlTexture {
     }
 
     GlRgbTexture(Size size) {
-        super(size);
+        super(size, WrapMode.REPEAT);
     }
 
     @Override
-    protected int doInit(Size size) {
-        int textureHandle = glGenTextures();
-        glBindTexture(GL_TEXTURE_2D, textureHandle);
-        glTexImage2D(GL_TEXTURE_2D, 0,  GL_RGB, size.getWidth(), size.getHeight(), 0, GL_RGB, GL_UNSIGNED_BYTE, 0);
+    protected void onInit() {
+        glTexImage2D(GL_TEXTURE_2D, 0,  GL_RGB, getWidth(), getHeight(), 0, GL_RGB, GL_UNSIGNED_BYTE, 0);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-        return textureHandle;
     }
 }

--- a/src/main/java/org/adddxdx/graphics/ImageTexture.java
+++ b/src/main/java/org/adddxdx/graphics/ImageTexture.java
@@ -16,19 +16,21 @@
  * along with adddxdx.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package org.adddxdx.graphics.support.textures;
+package org.adddxdx.graphics;
 
 import org.adddxdx.fio.Image;
-import org.adddxdx.graphics.GlTexture;
-import org.adddxdx.math.Size;
 
 import static org.lwjgl.opengl.GL11.*;
 
-public class Texture extends GlTexture {
+public class ImageTexture extends GlTexture {
     private final Image mImage;
 
-    public Texture(Image image) {
-        super(image.getSize());
+    public ImageTexture(Image image) {
+        this(image, WrapMode.REPEAT);
+    }
+
+    public ImageTexture(Image image, WrapMode wrapMode) {
+        super(image.getSize(), wrapMode);
         mImage = image;
     }
 
@@ -38,19 +40,14 @@ public class Texture extends GlTexture {
     }
 
     @Override
-    protected int doInit(Size size) {
-        int textureHandle = glGenTextures();
-        int glTextureFormat = getGlTextureFormat();
-
-        glBindTexture(GL_TEXTURE_2D, textureHandle);
-
+    protected void onInit() {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
-        glTexImage2D(GL_TEXTURE_2D, 0,
-                glTextureFormat, size.getWidth(), size.getHeight(), 0,
-                glTextureFormat, GL_UNSIGNED_BYTE, mImage.getImageBytes());
+        int glTextureFormat = getGlTextureFormat();
 
-        return textureHandle;
+        glTexImage2D(GL_TEXTURE_2D, 0,
+                glTextureFormat, getWidth(), getHeight(), 0,
+                glTextureFormat, GL_UNSIGNED_BYTE, mImage.getImageBytes());
     }
 }

--- a/src/main/java/org/adddxdx/graphics/StubTexture.java
+++ b/src/main/java/org/adddxdx/graphics/StubTexture.java
@@ -21,13 +21,12 @@ package org.adddxdx.graphics;
 import org.adddxdx.math.Size;
 
 import static org.lwjgl.opengl.GL11.*;
-import static org.lwjgl.opengl.GL12.GL_CLAMP_TO_EDGE;
 
 class StubTexture extends GlTexture {
     private final static int WIDTH = 1, HEIGHT = 1;
 
     StubTexture() {
-        super(new Size(WIDTH, HEIGHT));
+        super(new Size(WIDTH, HEIGHT), WrapMode.CLAMP_TO_BORDER);
     }
 
     @Override
@@ -36,19 +35,12 @@ class StubTexture extends GlTexture {
     }
 
     @Override
-    protected int doInit(Size size) {
-        int handle = glGenTextures();
-        glBindTexture(GL_TEXTURE_2D, handle);
-
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    protected void onInit() {
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 
         float data[] = { 1, 1, 1, 1 };
 
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, WIDTH, HEIGHT, 0, GL_RGBA, GL_FLOAT, data);
-
-        return handle;
     }
 }

--- a/src/main/java/org/adddxdx/graphics/Texture.java
+++ b/src/main/java/org/adddxdx/graphics/Texture.java
@@ -1,0 +1,41 @@
+package org.adddxdx.graphics;
+
+import org.adddxdx.math.Size;
+
+import static org.lwjgl.opengl.GL11.GL_REPEAT;
+import static org.lwjgl.opengl.GL12.GL_CLAMP_TO_EDGE;
+import static org.lwjgl.opengl.GL13.GL_CLAMP_TO_BORDER;
+import static org.lwjgl.opengl.GL14.GL_MIRRORED_REPEAT;
+
+public interface Texture {
+    int getWidth();
+
+    int getHeight();
+
+    Size getSize();
+
+    void setWrapMode(WrapMode wrapMode);
+
+    boolean isInitialized();
+
+    void init();
+
+    int bind(int textureUnitToUse);
+
+    enum WrapMode {
+        CLAMP_TO_EDGE(GL_CLAMP_TO_EDGE),
+        CLAMP_TO_BORDER(GL_CLAMP_TO_BORDER),
+        REPEAT(GL_REPEAT),
+        MIRRORED_REPEAT(GL_MIRRORED_REPEAT);
+
+        private int mGlWrapMode;
+
+        WrapMode(int glWrapMode) {
+            mGlWrapMode = glWrapMode;
+        }
+
+        int getGlWrapMode() {
+            return mGlWrapMode;
+        }
+    }
+}

--- a/src/main/java/org/adddxdx/graphics/TexturedMaterial.java
+++ b/src/main/java/org/adddxdx/graphics/TexturedMaterial.java
@@ -22,20 +22,22 @@ public abstract class TexturedMaterial extends Material {
     private final static String UNIFORM_TEXTURE = "mainTexture";
     private final static int TEXTURE_UNIT_TO_USE = 2;
 
-    private GlTexture mTexture;
+    private Texture mTexture;
 
     public TexturedMaterial() {
         mTexture = new StubTexture();
     }
 
-    public void setTexture(GlTexture texture) {
+    public void setTexture(Texture texture) {
         mTexture = texture;
     }
 
     @Override
     public void setupShader(RenderSettings settings, Shader shader) {
         if (mTexture != null) {
-            if (!mTexture.isInitialized()) mTexture.init();
+            if (!mTexture.isInitialized()) {
+                mTexture.init();
+            }
             shader.setUniform(UNIFORM_TEXTURE, mTexture.bind(TEXTURE_UNIT_TO_USE));
         }
     }


### PR DESCRIPTION
**Changes:**
- New method for Resources: `getTexture(String path, WrapMode wrapMode)`.
- ResourcesImpl holds instance of ResourceManager<Image>, not ResourceManager<Texture>, since Textures are not immutable now.
- All textures are subtypes of common interface `Texture`.