### PR TITLE
+ CompletionStage implementation that allows to execute tasks synchroneously

### DIFF
--- a/src/main/java/org/adddxdx/engine/futures/SyncDispatcher.java
+++ b/src/main/java/org/adddxdx/engine/futures/SyncDispatcher.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017
+ * This file is part of adddxdx.
+ *
+ * adddxdx is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * adddxdx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with adddxdx.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.adddxdx.engine.futures;
+
+import java.time.Duration;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+
+public class SyncDispatcher implements TaskQueueDispatcher {
+
+    private final Queue<Runnable> mTasks = new ConcurrentLinkedQueue<>();
+
+    public int dispatch(Duration timeSinceLastTick, long totalTicksCount) {
+        // TODO: Time measure
+        int executed = 0;
+        while (!mTasks.isEmpty()) {
+            Runnable task = mTasks.poll();
+            if (task != null) {
+                executed++;
+                task.run();
+            }
+        }
+        return executed;
+    }
+
+    public void enqueue(Runnable command) {
+        mTasks.add(command);
+    }
+
+    public boolean isNotEmpty() {
+        return !mTasks.isEmpty();
+    }
+}

--- a/src/main/java/org/adddxdx/engine/futures/SyncDispatcher.java
+++ b/src/main/java/org/adddxdx/engine/futures/SyncDispatcher.java
@@ -22,9 +22,7 @@ import java.time.Duration;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
-
 public class SyncDispatcher implements TaskQueueDispatcher {
-
     private final Queue<Runnable> mTasks = new ConcurrentLinkedQueue<>();
 
     public int dispatch(Duration timeSinceLastTick, long totalTicksCount) {

--- a/src/main/java/org/adddxdx/engine/futures/SyncDispatcher.java
+++ b/src/main/java/org/adddxdx/engine/futures/SyncDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017
+ * Copyright (C) 2017 Ostanin Igor
  * This file is part of adddxdx.
  *
  * adddxdx is free software: you can redistribute it and/or modify

--- a/src/main/java/org/adddxdx/engine/futures/SyncFuture.java
+++ b/src/main/java/org/adddxdx/engine/futures/SyncFuture.java
@@ -1,0 +1,439 @@
+/*
+ * Copyright (C) 2017
+ * This file is part of adddxdx.
+ *
+ * adddxdx is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * adddxdx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with adddxdx.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.adddxdx.engine.futures;
+
+import java.util.concurrent.*;
+import java.util.function.*;
+
+
+public class SyncFuture<T> implements Future<T>, CompletionStage<T> {
+
+    private final TaskQueueDispatcher mTaskQueue;
+    private final CompletableFuture<T> mInnerFuture;
+
+    public SyncFuture(TaskQueueDispatcher taskDispatcher, T object) {
+        this(taskDispatcher, CompletableFuture.completedFuture(object));
+    }
+
+    public SyncFuture(TaskQueueDispatcher taskDispatcher) {
+        this(taskDispatcher, new CompletableFuture<>());
+    }
+
+    private SyncFuture(TaskQueueDispatcher taskDispatcher, CompletableFuture<T> toWrap) {
+        this.mTaskQueue = taskDispatcher;
+        this.mInnerFuture = toWrap;
+    }
+
+    private <U> Runnable complete(SyncFuture<U> future, Runnable withAction) {
+        return complete(future, () -> { withAction.run(); return null; });
+    }
+
+    private <U> Runnable complete(CompletableFuture<U> future, Runnable withAction) {
+        return complete(future, () -> { withAction.run(); return null; });
+    }
+
+    private <U> Runnable complete(SyncFuture<U> future, Supplier<U> withResult) {
+        return () -> {
+            try {
+                future.complete(withResult.get());
+            }
+            catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        };
+    }
+
+    private <U> Runnable complete(CompletableFuture<U> future, Supplier<U> action) {
+        return () -> {
+            try {
+                future.complete(action.get());
+            }
+            catch (Throwable t) {
+                future.completeExceptionally(t);
+            }
+        };
+    }
+
+    public boolean complete(T object) {
+        return mInnerFuture.complete(object);
+    }
+
+    public boolean completeExceptionally(Throwable ex) {
+        return mInnerFuture.completeExceptionally(ex);
+    }
+
+    @Override
+    public <U> SyncFuture<U> thenApply
+            (Function<? super T, ? extends U> fn) {
+
+        SyncFuture<U> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture.thenAccept(res -> mTaskQueue.enqueue(complete(future, () -> fn.apply(res))));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public <U> SyncFuture<U> thenApplyAsync
+            (Function<? super T, ? extends U> fn) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenApplyAsync(fn));
+    }
+
+    @Override
+    public <U> SyncFuture<U> thenApplyAsync
+            (Function<? super T, ? extends U> fn, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenApplyAsync(fn, executor));
+    }
+
+    @Override
+    public SyncFuture<Void> thenAccept
+            (Consumer<? super T> action) {
+
+        SyncFuture<Void> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture.thenAccept(res -> mTaskQueue.enqueue(complete(future, () -> action.accept(res))));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public SyncFuture<Void> thenAcceptAsync
+            (Consumer<? super T> action) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenAcceptAsync(action));
+    }
+
+    @Override
+    public SyncFuture<Void> thenAcceptAsync
+            (Consumer<? super T> action, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenAcceptAsync(action, executor));
+    }
+
+    @Override
+    public SyncFuture<Void> thenRun
+            (Runnable action) {
+
+        SyncFuture<Void> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture.thenRun(() -> mTaskQueue.enqueue(complete(future, action)));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public SyncFuture<Void> thenRunAsync
+            (Runnable action) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenRunAsync(action));
+    }
+
+    @Override
+    public SyncFuture<Void> thenRunAsync
+            (Runnable action, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenRunAsync(action, executor));
+    }
+
+    @Override
+    public <U, V> SyncFuture<V> thenCombine
+            (CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+
+        SyncFuture<V> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture.thenAcceptBoth(other, (t, u) -> mTaskQueue.enqueue(complete(future, () -> fn.apply(t, u))));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public <U, V> SyncFuture<V> thenCombineAsync
+            (CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCombineAsync(other, fn));
+    }
+
+    @Override
+    public <U, V> SyncFuture<V> thenCombineAsync
+            (CompletionStage<? extends U> other, BiFunction<? super T, ? super U, ? extends V> fn, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCombineAsync(other, fn, executor));
+    }
+
+    @Override
+    public <U> SyncFuture<Void> thenAcceptBoth
+            (CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
+
+        SyncFuture<Void> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture
+                .thenAcceptBoth(other, (t, u) -> mTaskQueue.enqueue(complete(future, () -> action.accept(t, u))));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public <U> SyncFuture<Void> thenAcceptBothAsync
+            (CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenAcceptBothAsync(other, action));
+    }
+
+    @Override
+    public <U> SyncFuture<Void> thenAcceptBothAsync
+            (CompletionStage<? extends U> other, BiConsumer<? super T, ? super U> action, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenAcceptBothAsync(other, action, executor));
+    }
+
+    @Override
+    public SyncFuture<Void> runAfterBoth
+            (CompletionStage<?> other, Runnable action) {
+
+        SyncFuture<Void> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture.runAfterBoth(other, () -> mTaskQueue.enqueue(complete(future, action)));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public SyncFuture<Void> runAfterBothAsync
+            (CompletionStage<?> other, Runnable action) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.runAfterBothAsync(other, action));
+    }
+
+    @Override
+    public SyncFuture<Void> runAfterBothAsync
+            (CompletionStage<?> other, Runnable action, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.runAfterBothAsync(other, action, executor));
+    }
+
+    @Override
+    public <U> SyncFuture<U> applyToEither
+            (CompletionStage<? extends T> other, Function<? super T, U> fn) {
+
+        SyncFuture<U> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture.acceptEither(other, (res) -> mTaskQueue.enqueue(complete(future, () -> fn.apply(res))));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public <U> SyncFuture<U> applyToEitherAsync
+            (CompletionStage<? extends T> other, Function<? super T, U> fn) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.applyToEitherAsync(other, fn));
+    }
+
+    @Override
+    public <U> SyncFuture<U> applyToEitherAsync
+            (CompletionStage<? extends T> other, Function<? super T, U> fn, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.applyToEitherAsync(other, fn, executor));
+    }
+
+    @Override
+    public SyncFuture<Void> acceptEither
+            (CompletionStage<? extends T> other, Consumer<? super T> action) {
+
+        SyncFuture<Void> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture.acceptEither(other, (res) -> mTaskQueue.enqueue(complete(future, () -> action.accept(res))));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public SyncFuture<Void> acceptEitherAsync
+            (CompletionStage<? extends T> other, Consumer<? super T> action) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.acceptEitherAsync(other, action));
+    }
+
+    @Override
+    public SyncFuture<Void> acceptEitherAsync
+            (CompletionStage<? extends T> other, Consumer<? super T> action, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.acceptEitherAsync(other, action, executor));
+    }
+
+    @Override
+    public SyncFuture<Void> runAfterEither
+            (CompletionStage<?> other, Runnable action) {
+
+        SyncFuture<Void> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture.runAfterEither(other, () -> mTaskQueue.enqueue(complete(future, action)));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public SyncFuture<Void> runAfterEitherAsync
+            (CompletionStage<?> other, Runnable action) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.runAfterEitherAsync(other, action));
+    }
+
+    @Override
+    public SyncFuture<Void> runAfterEitherAsync
+            (CompletionStage<?> other, Runnable action, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.runAfterEitherAsync(other, action, executor));
+    }
+
+    @Override
+    public <U> SyncFuture<U> thenCompose
+            (Function<? super T, ? extends CompletionStage<U>> fn) {
+
+        CompletableFuture<CompletionStage<U>> dummy = new CompletableFuture<>();
+        CompletableFuture<U> composed = dummy.thenCompose(nextFuture -> nextFuture);
+
+        SyncFuture<U> future = new SyncFuture<>(mTaskQueue, composed);
+
+        mInnerFuture.thenAccept(t -> mTaskQueue.enqueue(complete(dummy, () -> fn.apply(t))));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public <U> SyncFuture<U> thenComposeAsync
+            (Function<? super T, ? extends CompletionStage<U>> fn) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenComposeAsync(fn));
+    }
+
+    @Override
+    public <U> SyncFuture<U> thenComposeAsync
+            (Function<? super T, ? extends CompletionStage<U>> fn, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenComposeAsync(fn));
+    }
+
+    @Override
+    public SyncFuture<T> exceptionally
+            (Function<Throwable, ? extends T> fn) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.exceptionally(fn));
+    }
+
+    @Override
+    public SyncFuture<T> whenComplete
+            (BiConsumer<? super T, ? super Throwable> action) {
+
+        SyncFuture<T> future = new SyncFuture<>(mTaskQueue);
+        mInnerFuture.whenComplete((r, e) -> mTaskQueue.enqueue(() -> {
+            try {
+                action.accept(r, e);
+            }
+            catch (Throwable t) {
+                if (e == null) future.completeExceptionally(t);
+                else future.completeExceptionally(e);
+            }
+            if (!future.isDone()) future.complete(r);
+
+        }));
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.thenCompose(t -> future));
+    }
+
+    @Override
+    public SyncFuture<T> whenCompleteAsync
+            (BiConsumer<? super T, ? super Throwable> action) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.whenCompleteAsync(action));
+    }
+
+    @Override
+    public SyncFuture<T> whenCompleteAsync
+            (BiConsumer<? super T, ? super Throwable> action, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.whenCompleteAsync(action, executor));
+    }
+
+    @Override
+    public <U> SyncFuture<U> handle
+            (BiFunction<? super T, Throwable, ? extends U> fn) {
+
+        SyncFuture<U> future = new SyncFuture<>(mTaskQueue);
+        CompletableFuture<Void> handle = mInnerFuture.handle((r, e) -> {
+            mTaskQueue.enqueue(() -> {
+                U result = null;
+                try {
+                    result = fn.apply(r, e);
+                }
+                catch (Throwable t) {
+                    if (e == null) future.completeExceptionally(t);
+                    else future.completeExceptionally(e);
+                }
+                if (!future.isDone()) future.complete(result);
+
+            });
+            return null;
+        });
+        return new SyncFuture<>(mTaskQueue, handle.thenCompose(t -> future));
+    }
+
+    @Override
+    public <U> SyncFuture<U> handleAsync
+            (BiFunction<? super T, Throwable, ? extends U> fn) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.handleAsync(fn));
+    }
+
+    @Override
+    public <U> SyncFuture<U> handleAsync
+            (BiFunction<? super T, Throwable, ? extends U> fn, Executor executor) {
+
+        return new SyncFuture<>(mTaskQueue, mInnerFuture.handleAsync(fn, executor));
+    }
+
+    @Override
+    public CompletableFuture<T> toCompletableFuture() {
+        return mInnerFuture;
+    }
+
+    @Override
+    public boolean cancel(boolean mayInterruptIfRunning) {
+        return mInnerFuture.cancel(mayInterruptIfRunning);
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return mInnerFuture.isCancelled();
+    }
+
+    @Override
+    public boolean isDone() {
+        return mInnerFuture.isDone();
+    }
+
+    @Override
+    public T get() throws InterruptedException, ExecutionException {
+        return mInnerFuture.get();
+    }
+
+    @Override
+    public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return mInnerFuture.get(timeout, unit);
+    }
+
+
+    static final SyncDispatcher defaultDispatcher = new SyncDispatcher();
+
+    public static <T> SyncFuture<T> supply(Supplier<T> supplier) {
+        SyncFuture<T> future = new SyncFuture<>(defaultDispatcher);
+        defaultDispatcher.enqueue(() -> future.complete(supplier.get()));
+        return future;
+    }
+
+    public static <T> SyncFuture<T> supplyAsync(Supplier<T> supplier) {
+        return new SyncFuture<>(defaultDispatcher, CompletableFuture.supplyAsync(supplier));
+    }
+
+    public static <T> SyncFuture<T> completedFuture(T result) {
+        return new SyncFuture<>(defaultDispatcher, result);
+    }
+}

--- a/src/main/java/org/adddxdx/engine/futures/SyncFuture.java
+++ b/src/main/java/org/adddxdx/engine/futures/SyncFuture.java
@@ -436,4 +436,8 @@ public class SyncFuture<T> implements Future<T>, CompletionStage<T> {
     public static <T> SyncFuture<T> completedFuture(T result) {
         return new SyncFuture<>(defaultDispatcher, result);
     }
+
+    public static SyncDispatcher getDefaultDispatcher() {
+        return defaultDispatcher;
+    }
 }

--- a/src/main/java/org/adddxdx/engine/futures/SyncFuture.java
+++ b/src/main/java/org/adddxdx/engine/futures/SyncFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017
+ * Copyright (C) 2017 Ostanin Igor
  * This file is part of adddxdx.
  *
  * adddxdx is free software: you can redistribute it and/or modify

--- a/src/main/java/org/adddxdx/engine/futures/TaskQueueDispatcher.java
+++ b/src/main/java/org/adddxdx/engine/futures/TaskQueueDispatcher.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2017
+ * This file is part of adddxdx.
+ *
+ * adddxdx is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * adddxdx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with adddxdx.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.adddxdx.engine.futures;
+
+import java.time.Duration;
+
+public interface TaskQueueDispatcher {
+
+    int dispatch(Duration timeSinceLastTick, long totalTicksCount);
+
+    void enqueue(Runnable task);
+}

--- a/src/main/java/org/adddxdx/engine/futures/TaskQueueDispatcher.java
+++ b/src/main/java/org/adddxdx/engine/futures/TaskQueueDispatcher.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017
+ * Copyright (C) 2017 Ostanin Igor
  * This file is part of adddxdx.
  *
  * adddxdx is free software: you can redistribute it and/or modify

--- a/src/main/java/org/adddxdx/engine/futures/TaskQueueDispatcher.java
+++ b/src/main/java/org/adddxdx/engine/futures/TaskQueueDispatcher.java
@@ -21,7 +21,6 @@ package org.adddxdx.engine.futures;
 import java.time.Duration;
 
 public interface TaskQueueDispatcher {
-
     int dispatch(Duration timeSinceLastTick, long totalTicksCount);
 
     void enqueue(Runnable task);

--- a/src/test/java/org/adddxdx/engine/futures/SyncFutureTest.java
+++ b/src/test/java/org/adddxdx/engine/futures/SyncFutureTest.java
@@ -1,0 +1,277 @@
+/*
+ * Copyright (C) 2017
+ * This file is part of adddxdx.
+ *
+ * adddxdx is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * adddxdx is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with adddxdx.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.adddxdx.engine.futures;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Consumer;
+
+import static org.junit.Assert.assertTrue;
+
+public class SyncFutureTest {
+
+    private boolean DEBUG = true;
+
+    private <T> T loopUntilNotDone(Future<T> future) throws ExecutionException, InterruptedException {
+        int loopc = 0;
+        int counter = 0;
+        while (!(future.isDone() || future.isCancelled())) {
+            int executed = SyncFuture.defaultDispatcher.dispatch(Duration.ofSeconds(0), 10L);
+            counter += executed;
+            if (executed > 0) loopc++;
+        }
+
+        if (DEBUG) {
+            System.out.printf("Finished in %s iterations\n", loopc);
+            System.out.printf("%s synchroneous tasks executed\n", counter);
+            System.out.printf("Output: %s\n", future.get());
+        }
+        return future.get();
+    }
+
+    class TestException extends RuntimeException {
+
+        TestException(String message) {
+            super(message);
+        }
+    }
+
+    @Test
+    public void exceptionallyTest() throws Exception {
+        CompletableFuture<Integer> f1 = new CompletableFuture<>();
+        f1.completeExceptionally(new RuntimeException());
+        CompletableFuture<Integer> e1 = f1.exceptionally(throwable -> 1);
+
+        CompletableFuture<Integer> f2 = CompletableFuture.supplyAsync(() -> 10);
+        CompletableFuture<Integer> e2 = f2.exceptionally(throwable -> 1);
+
+        assert 1 == loopUntilNotDone(e1);
+        assert 10 == loopUntilNotDone(e2);
+    }
+
+    @Test
+    public void chainMethodsTest() throws Exception {
+        SyncFuture<Integer> future = SyncFuture.completedFuture(0);
+
+        SyncFuture<Integer> f1 = future.thenApply(i -> i + 1);
+        SyncFuture<Integer> f2 = future.thenApply(i -> i + 2);
+        f1.thenRun(() -> System.out.println("thenRun"));
+        f2.thenAccept(i -> System.out.printf("thenAccept(%s)\n", i));
+
+        SyncFuture<Integer> f3 = f1.thenCombine(f2, (a, b) -> a * 100 + b); // 102
+        SyncFuture<Integer> f4 = f2.thenCombine(f1, (a, b) -> a * 100 + b); // 201
+        SyncFuture<Void> f5 = f1.acceptEither(f2, new Consumer<Integer>() {
+            private int runCounter = 0;
+
+            @Override
+            public void accept(Integer a) {
+                assert a == 1 || a == 2;
+                if (runCounter++ > 0)
+                    Assert.fail();
+            }
+        });
+
+        f1.runAfterEither(f2, new Runnable() {
+            private int runCounter = 0;
+
+            @Override
+            public void run() {
+                System.out.println("runAfterEither");
+                if (runCounter++ > 0)
+                    Assert.fail();
+            }
+        });
+
+
+        SyncFuture<Void> f6 = f5.runAfterBoth(f4, () -> System.out.println("runAfterBoth"));
+        SyncFuture<Void> f7 = f3.thenAcceptBoth(f4, (_102, _201) -> {
+            assertTrue(102 == _102);
+            assertTrue(201 == _201);
+            System.out.println("thenAcceptBoth");
+        });
+
+        SyncFuture<Integer> f8 = f1.applyToEither(f3, integer -> {
+            throw new TestException("planned");
+        });
+
+        SyncFuture<Integer> f9 = f8.exceptionally(throwable -> {
+            Assert.assertEquals(TestException.class, throwable.getCause().getClass());
+            return -1;
+        });
+
+        SyncFuture<Void> f99 = f7.thenCompose(aVoid -> f6.thenCompose(aVoid1 -> f6.thenCompose(aVoid3 -> f6)));
+
+
+        loopUntilNotDone(f99);
+        assert 102 == loopUntilNotDone(f3);
+        assert 201 == loopUntilNotDone(f4);
+        assert -1 == loopUntilNotDone(f9);
+        loopUntilNotDone(f5);
+        loopUntilNotDone(f6);
+        loopUntilNotDone(f7);
+    }
+
+    @Test
+    public void whenCompleteTest() throws Exception {
+        System.out.println(Thread.currentThread().getName());
+
+        SyncFuture<Integer> future = SyncFuture.supply(() -> 10);
+
+        SyncFuture<Integer> future0 = future
+                .thenApply(i -> i + 1)
+                .whenComplete((integer, throwable) -> {
+                    assertTrue(integer != null && integer == 11);
+                    System.out.print("Completed normaly ");
+                    System.out.println(Thread.currentThread().getName());
+                });
+
+        SyncFuture<Integer> future1 = future.thenApply(i -> {
+            if (true) throw new TestException("woooooop");
+            else return i + 1;
+        }).whenComplete((o, throwable) -> {
+            assertTrue(throwable != null);
+            System.out.print("Completed exceptionaly ");
+            System.out.println(Thread.currentThread().getName());
+        }).exceptionally(t -> 11);
+
+        assert 11 == loopUntilNotDone(future0);
+        assert 11 == loopUntilNotDone(future1);
+    }
+
+    @Test
+    public void handleTest() throws Exception {
+        System.out.println(Thread.currentThread().getName());
+
+        SyncFuture<Integer> future = SyncFuture.supply(() -> 10);
+
+        SyncFuture<Integer> future0 = future
+                .thenApply(i -> i + 1)
+                .handle((integer, throwable) -> {
+                    assertTrue(integer != null && integer == 11);
+                    System.out.print("Completed normaly ");
+                    System.out.println(Thread.currentThread().getName());
+                    return integer;
+                });
+
+        SyncFuture<String> future1 = future.thenApply(i -> {
+            if (true) throw new TestException("woooooop");
+            else return i + 1;
+        }).handle((o, throwable) -> {
+            assertTrue(throwable != null);
+            System.out.print("Completed exceptionaly ");
+            System.out.println(Thread.currentThread().getName());
+            return "Hello";
+        });
+
+        assert 11 == loopUntilNotDone(future0);
+        assert Objects.equals("Hello", loopUntilNotDone(future1));
+    }
+
+    @Test
+    public void basicUsageTest() throws ExecutionException, InterruptedException {
+
+        SyncFuture<Integer> future = SyncFuture.supply(() -> 10).thenApplyAsync(d -> {
+            System.out.println(d.getClass());
+            return d.toString();
+        }).thenApply(s -> {
+            System.out.println(s.getClass());
+            return 1;
+        });
+
+        assert 1 == loopUntilNotDone(future);
+    }
+
+    @Test(expected = CancellationException.class)
+    public void cancelTest() throws Throwable {
+        SyncFuture<Integer> future = SyncFuture.supply(() -> 10);
+        future = future.thenApply(i -> i + 1);
+
+        boolean cancel = future.cancel(false);
+        assert cancel : "test suite assumes that cancel was succed";
+
+        SyncFuture<Integer> neverRunned = future.thenApply(i -> {
+            Assert.fail();
+            return i + 1;
+        });
+
+        try {
+            loopUntilNotDone(neverRunned);
+        }
+        catch (ExecutionException e) {
+            throw e.getCause();
+        }
+        Assert.fail();
+    }
+
+
+    @Test
+    public void syncAsyncTreeTopologyRecallsTest() throws Exception {
+
+        SyncFuture<Float> future = SyncFuture.completedFuture(1f)
+                .thenApplyAsync(i -> i * 10)
+                .thenApply(i -> i / 10);
+
+
+        SyncFuture<Float> f1 = future
+                .thenApplyAsync(i -> i * 10)
+                .thenApply(i -> i / 10)
+                .thenApplyAsync(i -> i * 100)
+                .thenApply(i -> i / 10);
+
+        SyncFuture<Float> f2 = future
+                .thenApplyAsync(i -> i * 11)
+                .thenApply(i -> i / 10);
+
+        assert 10f == loopUntilNotDone(f1);
+        assert 1.1f == loopUntilNotDone(f2);
+    }
+
+    @Test
+    public void chainedSyncroneousFunctionsTest() throws ExecutionException, InterruptedException {
+        SyncFuture<Integer> future = SyncFuture.supply(() -> 10)
+                .thenApply(d -> d * 10)
+                .thenApply(d -> d * 10)
+                .thenApply(d -> d * 10)
+                .thenApply(d -> d * 10);
+
+        assert 100000 == loopUntilNotDone(future);
+    }
+
+    private CompletableFuture<Integer> futureRecursion(CompletableFuture<Integer> cf) {
+        return cf.thenComposeAsync(integer -> {
+            if (integer > 1000)
+                return CompletableFuture.completedFuture(integer);
+            return futureRecursion(cf.thenApplyAsync(r -> r + 1));
+        });
+    }
+
+    @Test
+    public void futureRecursionExampleTest() throws Exception {
+        CompletableFuture<Integer> f2 = futureRecursion(CompletableFuture.completedFuture(1));
+        assert 1001 == loopUntilNotDone(f2);
+    }
+
+}

--- a/src/test/java/org/adddxdx/engine/futures/SyncFutureTest.java
+++ b/src/test/java/org/adddxdx/engine/futures/SyncFutureTest.java
@@ -32,16 +32,17 @@ import java.util.function.Consumer;
 import static org.junit.Assert.assertTrue;
 
 public class SyncFutureTest {
-
-    private boolean DEBUG = true;
+    private final static boolean DEBUG = true;
 
     private <T> T loopUntilNotDone(Future<T> future) throws ExecutionException, InterruptedException {
         int loopc = 0;
         int counter = 0;
         while (!(future.isDone() || future.isCancelled())) {
-            int executed = SyncFuture.defaultDispatcher.dispatch(Duration.ofSeconds(0), 10L);
+            int executed = SyncFuture.DEFAULT_DISPATCHER.dispatch(Duration.ofSeconds(0), 10L);
             counter += executed;
-            if (executed > 0) loopc++;
+            if (executed > 0) {
+                loopc++;
+            }
         }
 
         if (DEBUG) {
@@ -89,8 +90,9 @@ public class SyncFutureTest {
             @Override
             public void accept(Integer a) {
                 assert a == 1 || a == 2;
-                if (runCounter++ > 0)
+                if (runCounter++ > 0) {
                     Assert.fail();
+                }
             }
         });
 
@@ -100,8 +102,9 @@ public class SyncFutureTest {
             @Override
             public void run() {
                 System.out.println("runAfterEither");
-                if (runCounter++ > 0)
+                if (runCounter++ > 0) {
                     Assert.fail();
+                }
             }
         });
 
@@ -149,8 +152,12 @@ public class SyncFutureTest {
                 });
 
         SyncFuture<Integer> future1 = future.thenApply(i -> {
-            if (true) throw new TestException("woooooop");
-            else return i + 1;
+            if (true) {
+                throw new TestException("woooooop");
+            }
+            else {
+                return i + 1;
+            }
         }).whenComplete((o, throwable) -> {
             assertTrue(throwable != null);
             System.out.print("Completed exceptionaly ");
@@ -177,8 +184,12 @@ public class SyncFutureTest {
                 });
 
         SyncFuture<String> future1 = future.thenApply(i -> {
-            if (true) throw new TestException("woooooop");
-            else return i + 1;
+            if (true)  {
+                throw new TestException("woooooop");
+            }
+            else {
+                return i + 1;
+            }
         }).handle((o, throwable) -> {
             assertTrue(throwable != null);
             System.out.print("Completed exceptionaly ");
@@ -262,8 +273,9 @@ public class SyncFutureTest {
 
     private CompletableFuture<Integer> futureRecursion(CompletableFuture<Integer> cf) {
         return cf.thenComposeAsync(integer -> {
-            if (integer > 1000)
+            if (integer > 1000) {
                 return CompletableFuture.completedFuture(integer);
+            }
             return futureRecursion(cf.thenApplyAsync(r -> r + 1));
         });
     }


### PR DESCRIPTION

`SyncFuture` is `CompletionStage` implementation that uses `CompletableFuture` class in backend for handle `*Async` methods.

But for  the rest methods that implementation acts differently. 
Assume we have the code below:
```java
SyncFuture<Void> future = SyncFuture.supplyAsync(() -> x).thenAccept(x -> System.out.println(x));
```
`x` will not appear on the `System.out`, because of `thenAccept` (like **all** of implemented `CompletionStage` methods that ends on `Async`) only **queues** given task to inner `TaskQueueDispatcher`. This task will be executed **only** when we **manually** invoke `.dispatch` method.

For futures created through static fabric methods there are `defaultDispatcher` used. And it is accesible through `SyncFuture.getDefaultDispatcher` method.

```java
SyncFuture.getDefaultDispatcher().dispatch(...);
```